### PR TITLE
fix a problem where heartbeat wasn't going to the proper port

### DIFF
--- a/src/WebPortal.ts
+++ b/src/WebPortal.ts
@@ -25,7 +25,7 @@ type CreateServerResponseListener = (
 let createServer: (
   responseListener: CreateServerResponseListener
 ) => HttpServer | HttpsServer;
-let get: (url: string) => ClientRequest;
+let get: (url: string, options: { port: number }) => ClientRequest;
 switch (serverProtocol) {
   case 'http': {
     createServer = createHttpServer;
@@ -48,7 +48,7 @@ switch (serverProtocol) {
 function getEndpoint(endpoint: string): Promise<string> {
   const url = resolve(GlobalConfig.webportalUrl, endpoint);
   return new Promise((resolvePromise, reject) => {
-    const request = get(url);
+    const request = get(url, { port: GlobalConfig.webportalPort });
     request.on('error', err => reject(err));
     request.on('response', (response: IncomingMessage) => {
       response.on('error', err => reject(err));


### PR DESCRIPTION
The heartbeat within `WebPortal` wasn't going to the proper port (was defaulting to 80). This was causing the bot to shut down after 15 minutes. Everything looks like it works locally and should theoretically fix the problem, but we'll see when we deploy it.